### PR TITLE
Add assertion to MainWindow

### DIFF
--- a/src/main/java/duke/launcher/MainWindow.java
+++ b/src/main/java/duke/launcher/MainWindow.java
@@ -43,6 +43,7 @@ public class MainWindow extends AnchorPane {
     @FXML
     private void handleUserInput() {
         String input = userInput.getText();
+        assert !input.equals("");
         String response = duke.getResponse(input);
         dialogContainer.getChildren().addAll(
                 DialogBox.getUserDialog(input, userImage),


### PR DESCRIPTION
MainWindow checks for and asserts that the user input is not empty. This is necessary as previously when a user inputted an empty string, the message will be "displayed" as a non-existent dialog box with an invalid command error from the bot.